### PR TITLE
Exit worker threads immediately when their input channels disconnect

### DIFF
--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -39,14 +39,13 @@ impl SpectrumCalculator {
         }
     }
 
-    pub fn run(&mut self) -> ! {
-        loop {
-            if let Ok(window) = self.window_rx.recv() {
-                let spectrum = Self::process_window(&window);
+    pub fn run(&mut self) {
+        while let Ok(window) = self.window_rx.recv() {
+            let spectrum = Self::process_window(&window);
 
-                self.spectrum_tx.send(spectrum).unwrap();
-            }
+            self.spectrum_tx.send(spectrum).unwrap();
         }
+        log::debug!("SpectrumCalculator thread exiting");
     }
 
     pub fn process_window(window: &ImageBuffer<Rgb<u8>, Vec<u8>>) -> SpectrumRgb {


### PR DESCRIPTION
This stops the worker threads from sitting in a tight busy loop consuming 100% CPU if the channels they listen for input on are ever dropped.

This can for example happen if the thread owning the sender panics. Even if the panic does result in the process eventually aborting, this stops the worker threads from going crazy while the shut down happens.

I tested this by inserting a panic in the main thread. And indeed, the camera thread were doing a few thousand loops before the process died. This way should be more efficient and cleaner.

The diff is 99% indentation changes only. The only real change is that the `loop` + `if let` was joined into a `while let`. And then a `log::debug!` was added at the end of both `run` methods.