### PR TITLE
Add backpressure handling between camera and spectrum analyzer

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,13 @@ fn main() -> eframe::Result {
     init_logging();
 
     let frame = Arc::new(Mutex::new(None));
+
+    // Image buffer holding the last read frame from the camera. Consumed by the GUI to display the camera feed.
     let (frame_tx, frame_rx) = (frame.clone(), frame.clone());
-    let (window_tx, window_rx) = flume::unbounded();
+    // Channel transporting image buffers from the camera thread to the spectrum calculator thread.
+    // This is bounded to provide backpressure handling. If the spectrum calculator is slower than the
+    // framerate of the camera, frames will be dropped instead of filling up the memory.
+    let (window_tx, window_rx) = flume::bounded(5);
     let (spectrum_tx, spectrum_rx) = flume::bounded(1000);
     let (config_tx, config_rx) = flume::unbounded();
     let (result_tx, result_rx) = flume::unbounded();


### PR DESCRIPTION
I'm not sure if there is any reasonable hardware setup where this is a big problem in practice. But having an unbounded stream of fairly sizable objects without any backpressure handling seems like a risk to me.

This PR makes the program drop frames if the camera produce frames faster than the spectrum analyzer can analyze them, instead of filling up the available memory.

Both if this is wanted at all, and what the channel size should be, boils down to how one wants the program to behave in stressed situations. If the intention is only to have the user view the spectrum in real time, surely dropping anything but the latest frame is desirable. If there are two frames available, an old one and a new one, anything but the newest is probably garbage. But if one uses this tool in ways I touch upon in #7, then maybe the user want to make sure they get a consistent feed without a high risk for drops, justifying a larger buffer size. I settled on five as a low but not too low number of frames. This allows the spectrum analyzer to fall slightly behind if there is some temporary high load on the machine and the thread scheduling is unfavorable to the spectrum analyzer.

What do you think about the log level? I first logged it as debug, but later upgraded it to a warning. I think anything between debug and warn could be valid really. But I upgraded it to a warning since this is not supposed to happen really, and the user might want to know that their view of the spectrum feed is not complete.