### PR TITLE
Fix error in camera controls when there are multiple cameras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Pause/resume camera stream
 
+### Fixed
+
+- Fix crash triggered by opening camera controls when multiple cameras are present ([#10]).
+
 ## [0.2.0] - 2025-02-19
 
 ### Added
@@ -28,5 +32,6 @@ Initial release
 
 
 [unreleased]: https://github.com/DerFetzer/spectro-cam-rs/compare/0.2.0...HEAD
+[#10]: https://github.com/DerFetzer/spectro-cam-rs/issues/10
 [0.2.0]: https://github.com/DerFetzer/spectro-cam-rs/releases/tag/0.2.0
 [0.1.0]: https://github.com/DerFetzer/spectro-cam-rs/releases/tag/0.1.0

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -130,13 +130,11 @@ impl SpectrometerGui {
     }
 
     fn refresh_controls(&mut self) {
+        let camera_info = self.camera_info.get_index(self.config.camera_id).unwrap().1;
         let requested_format = RequestedFormat::new::<RgbFormat>(RequestedFormatType::Exact(
             self.config.camera_format.unwrap(),
         ));
-        match Camera::new(
-            CameraIndex::Index(self.config.camera_id as u32),
-            requested_format,
-        ) {
+        match Camera::new(camera_info.info.index().clone(), requested_format) {
             Ok(cam) => {
                 self.camera_controls = cam
                     .camera_controls()
@@ -151,20 +149,6 @@ impl SpectrometerGui {
             Err(e) => {
                 error!("Could not refresh camera controls: {e}");
             }
-        }
-        if let Ok(cam) = Camera::new(
-            CameraIndex::Index(self.config.camera_id as u32),
-            requested_format,
-        ) {
-            self.camera_controls = cam
-                .camera_controls()
-                .unwrap_or_default()
-                .into_iter()
-                .filter(|c| {
-                    !c.flag().contains(&KnownCameraControlFlag::ReadOnly)
-                        && !c.flag().contains(&KnownCameraControlFlag::WriteOnly)
-                })
-                .collect();
         }
     }
 


### PR DESCRIPTION
First of all, thanks a lot for this nice tool!

This PR fixes the bug reported in #10. The issue was using the internal `camera_id` in the `Camera::new` call instead of the index provided by nokhwa.

Also removes some duplicated code that was run twice.